### PR TITLE
Use `arrow.array` instead of `PyBytes` to enables zero copy

### DIFF
--- a/carla/carla_control_op.py
+++ b/carla/carla_control_op.py
@@ -7,7 +7,7 @@ from carla import Client, VehicleControl, command
 
 CARLA_SIMULATOR_HOST = "localhost"
 CARLA_SIMULATOR_PORT = "2000"
-STEER_GAIN = 0.7
+STEER_GAIN = 2
 client = Client(CARLA_SIMULATOR_HOST, int(CARLA_SIMULATOR_PORT))
 client.set_timeout(30.0)
 

--- a/carla/carla_control_op.py
+++ b/carla/carla_control_op.py
@@ -51,7 +51,7 @@ class Operator:
         """Handle input.
         Args:
             dora_input["id"](str): Id of the input declared in the yaml configuration
-            dora_input["data"] (bytes): Bytes message of the input
+            dora_input["value"] (arrow.array(UInt8)): Bytes message of the input
             send_output (Callable[[str, bytes]]): Function enabling sending output back to dora.
         """
 
@@ -65,8 +65,8 @@ class Operator:
         if "control" != dora_input["id"]:
             return DoraStatus.CONTINUE
 
-        [throttle, target_angle, brake] = np.frombuffer(
-            dora_input["data"], np.float16
+        [throttle, target_angle, brake] = np.array(dora_input["value"]).view(
+            np.float16
         )
 
         steer = radians_to_steer(target_angle, STEER_GAIN)

--- a/carla/carla_gps_op.py
+++ b/carla/carla_gps_op.py
@@ -1,11 +1,13 @@
 from typing import Callable
 
 import numpy as np
+import pyarrow as pa
 from _dora_utils import closest_vertex
 from _hd_map import HDMap
 from dora import DoraStatus
 from scipy.spatial.transform import Rotation as R
 
+pa.array([])
 from carla import Map
 
 # Planning general
@@ -130,7 +132,7 @@ class Operator:
             if len(self.waypoints) == 0:
                 send_output(
                     "gps_waypoints",
-                    self.waypoints.tobytes(),
+                    pa.array(self.waypoints.view(np.uint8).ravel()),
                     dora_input["metadata"],
                 )  # World coordinate
                 return DoraStatus.CONTINUE
@@ -144,7 +146,11 @@ class Operator:
 
             send_output(
                 "gps_waypoints",
-                filter_consecutive_duplicate(self.waypoints_array).tobytes(),
+                pa.array(
+                    filter_consecutive_duplicate(self.waypoints_array)
+                    .view(np.uint8)
+                    .ravel()
+                ),
                 dora_input["metadata"],
             )  # World coordinate
 

--- a/carla/carla_gps_op.py
+++ b/carla/carla_gps_op.py
@@ -51,7 +51,7 @@ class Operator:
     ):
 
         if "position" == dora_input["id"]:
-            self.position = np.frombuffer(dora_input["data"], np.float32)
+            self.position = np.array(dora_input["value"]).view(np.float32)
             return DoraStatus.CONTINUE
 
         elif "opendrive" == dora_input["id"]:
@@ -61,9 +61,9 @@ class Operator:
             return DoraStatus.CONTINUE
 
         elif "objective_waypoints" == dora_input["id"]:
-            self.objective_waypoints = np.frombuffer(
-                dora_input["data"], np.float32
-            ).reshape((-1, 3))
+            self.objective_waypoints = (
+                np.array(dora_input["value"]).view(np.float32).reshape((-1, 3))
+            )
 
             if self.hd_map is None or len(self.position) == 0:
                 print("No map within the gps or position")

--- a/carla/carla_source_node.py
+++ b/carla/carla_source_node.py
@@ -7,12 +7,8 @@ import numpy as np
 import pyarrow as pa
 
 pa.array([])  # See: https://github.com/apache/arrow/issues/34994
-from _generate_world import (
-    add_camera,
-    add_lidar,
-    spawn_actors,
-    spawn_driving_vehicle,
-)
+from _generate_world import (add_camera, add_lidar, spawn_actors,
+                             spawn_driving_vehicle)
 from dora import Node
 from numpy import linalg as LA
 from opentelemetry import trace
@@ -20,12 +16,12 @@ from opentelemetry.exporter.jaeger.thrift import JaegerExporter
 from opentelemetry.sdk.resources import SERVICE_NAME, Resource
 from opentelemetry.sdk.trace import TracerProvider
 from opentelemetry.sdk.trace.export import BatchSpanProcessor
-from opentelemetry.trace.propagation.tracecontext import (
-    TraceContextTextMapPropagator,
-)
+from opentelemetry.trace.propagation.tracecontext import \
+    TraceContextTextMapPropagator
 from scipy.spatial.transform import Rotation as R
 
-from carla import Client, Location, Rotation, Transform, VehicleControl, command
+from carla import (Client, Location, Rotation, Transform, VehicleControl,
+                   command)
 
 
 def radians_to_steer(rad: float, steer_gain: float):
@@ -89,7 +85,7 @@ LABELS = "image"
 IMAGE_WIDTH = 1920
 IMAGE_HEIGHT = 1080
 OBJECTIVE_WAYPOINTS = np.array([[234, 59, 39]], np.float32).ravel()
-STEER_GAIN = 0.7
+STEER_GAIN = 2
 
 lidar_pc = None
 depth_frame = None

--- a/carla/carla_source_node.py
+++ b/carla/carla_source_node.py
@@ -195,8 +195,8 @@ def main():
 for event in node:
     if event["type"] == "INPUT":
         if event["id"] == "control":
-            [throttle, target_angle, brake] = np.frombuffer(
-                event["data"], np.float16
+            [throttle, target_angle, brake] = np.array(event["value"]).view(
+                np.float16
             )
 
             steer = radians_to_steer(target_angle, STEER_GAIN)

--- a/carla/oasis_agent.py
+++ b/carla/oasis_agent.py
@@ -14,7 +14,7 @@ from carla import VehicleControl
 
 IMAGE_WIDTH = 1920
 IMAGE_HEIGHT = 1080
-STEER_GAIN = 1
+STEER_GAIN = 2
 AVERAGE_WINDOW = 10
 
 node = Node()

--- a/carla/oasis_agent.py
+++ b/carla/oasis_agent.py
@@ -298,7 +298,7 @@ class DoraAgent(AutonomousAgent):
                 event = node.next()
                 if event["type"] == "INPUT":
                     input_id = event["id"]
-                    value = event["data"]
+                    value = event["value"]
 
                     if input_id == "tick" and iteration > 0 and iteration < 4:
                         print(
@@ -312,7 +312,7 @@ class DoraAgent(AutonomousAgent):
                     elif input_id == "control":
                         break
 
-            [throttle, target_angle, brake] = np.frombuffer(value, np.float16)
+            [throttle, target_angle, brake] = np.array(value).view(np.float16)
 
             steer = radians_to_steer(target_angle, STEER_GAIN)
             vec_control = VehicleControl(

--- a/graphs/tutorials/webcam_yolov5.yaml
+++ b/graphs/tutorials/webcam_yolov5.yaml
@@ -21,4 +21,3 @@ nodes:
       inputs:
         image: webcam/image
         obstacles_bbox: yolov5/bbox
-        tick: dora/timer/millis/100

--- a/install_requirements.txt
+++ b/install_requirements.txt
@@ -6,6 +6,7 @@ scikit-learn==1.0.2
 pytest
 absl-py
 gdown
+pyarrow
 # Old dependencies to double check  
 cvxpy
 erdos>=0.3.1

--- a/operators/fot_op.py
+++ b/operators/fot_op.py
@@ -192,18 +192,18 @@ class Operator:
 
         if dora_input["id"] == "position":
             self.last_position = self.position
-            self.position = np.frombuffer(dora_input["data"], np.float32)
+            self.position = np.array(dora_input["value"]).view(np.float32)
             if len(self.last_position) == 0:
                 self.last_position = self.position
             return DoraStatus.CONTINUE
 
         elif dora_input["id"] == "speed":
-            self.speed = np.frombuffer(dora_input["data"], np.float32)
+            self.speed = np.array(dora_input["value"]).view(np.float32)
             return DoraStatus.CONTINUE
 
         elif dora_input["id"] == "obstacles":
-            obstacles = np.frombuffer(dora_input["data"], np.float32).reshape(
-                (-1, 5)
+            obstacles = (
+                np.array(dora_input["value"]).view(np.float32).reshape((-1, 5))
             )
             if len(self.last_obstacles) > 0:
                 self.obstacles = np.concatenate(
@@ -213,14 +213,16 @@ class Operator:
                 self.obstacles = obstacles
 
         elif dora_input["id"] == "global_lanes":
-            lanes = np.frombuffer(dora_input["data"], np.float32).reshape(
-                (-1, 60, 3)
+            lanes = (
+                np.array(dora_input["value"])
+                .view(np.float32)
+                .reshape((-1, 60, 3))
             )
             self.lanes = lanes
             return DoraStatus.CONTINUE
 
         elif "gps_waypoints" == dora_input["id"]:
-            waypoints = np.frombuffer(dora_input["data"], np.float32)
+            waypoints = np.array(dora_input["value"]).view(np.float32)
             waypoints = waypoints.reshape((-1, 3))[:, :2]
             self.gps_waypoints = waypoints
             return DoraStatus.CONTINUE

--- a/operators/obstacle_location_op.py
+++ b/operators/obstacle_location_op.py
@@ -1,3 +1,62 @@
+""" 
+# Obstacle location operator
+
+The obstacle location operator match bounding box with depth frame to find an approximative position of obstacles.
+
+There is two logic within it:
+- One is for the ground dot for lane detection.
+- One is for bounding box obstacle localisation.
+
+Both logic are based on he computation of the projection in 2D space of the lidar 3D point and then reusing the index to get the 3D position.
+
+- In the case of ground dot detection, the approximation is based on a knnr, as we might not have enough data on the floor.
+- In the case of bounding box, we use first quantile closest point within the bounding box to estimate the distance. We use the first quantile closest point to remove the noise.
+
+The mecanism to project the lidar point cloud into a 2D is also used in the `plot.py` operator. You can use the input `lidar_pc` within it to help you debug.
+
+## Inputs
+
+- 2D Obstacles bounding box.
+
+## Outputs
+
+- 3D position of obstacles as dot.
+
+
+## Graph Description
+
+```yaml
+  - id: obstacle_location_op
+    operator: 
+      outputs:
+        - obstacles
+      inputs:
+        lidar_pc: oasis_agent/lidar_pc
+        obstacles_bbox: yolov5/bbox
+        position: oasis_agent/position
+      python: ../../operators/obstacle_location_op.py
+```
+
+## Graph Viz
+
+```mermaid
+        flowchart TB
+  oasis_agent
+subgraph yolov5
+  yolov5/op[op]
+end
+subgraph fot_op
+  fot_op/op[op]
+end
+subgraph obstacle_location_op
+  obstacle_location_op/op[op]
+end
+  oasis_agent -- lidar_pc --> obstacle_location_op/op
+  yolov5/op -- bbox as obstacles_bbox --> obstacle_location_op/op
+  oasis_agent -- position --> obstacle_location_op/op
+  obstacle_location_op/op -- obstacles --> fot_op/op
+```
+"""
 from typing import Callable
 
 import numpy as np

--- a/operators/pid_control_op.py
+++ b/operators/pid_control_op.py
@@ -47,7 +47,7 @@ def compute_throttle_and_brake(pid, current_speed: float, target_speed: float):
         target_speed (:obj:`float`): The target speed to reach (in m/s).
 
     Returns:
-        Throttle and brake dora_input["data"]s.
+        Throttle and brake.
     """
     if current_speed < 0:
         print("Current speed is negative: {}".format(current_speed))
@@ -101,7 +101,7 @@ class PIDLongitudinalController(object):
             current_speed (:obj:`float`): Current speed in m/s.
 
         Returns:
-            Throttle and brake dora_input["data"]s.
+            Throttle, brake and steering.
         """
         # Transform to km/h
         error = (target_speed - current_speed) * 3.6
@@ -162,7 +162,7 @@ class Operator:
         """Handle input.
         Args:
             dora_input["id"](str): Id of the input declared in the yaml configuration
-            dora_input["data"] (bytes): Bytes message of the input
+            dora_input["value"] (arrow.array(UInt8)): Bytes message of the input
             send_output (Callable[[str, bytes]]): Function enabling sending output back to dora.
         """
 
@@ -171,7 +171,7 @@ class Operator:
             return DoraStatus.CONTINUE
 
         elif dora_input["id"] == "speed":
-            self.speed = np.frombuffer(dora_input["data"], np.float32)
+            self.speed = np.array(dora_input["value"]).view(np.float32)
             return DoraStatus.CONTINUE
 
         elif "waypoints" == dora_input["id"]:

--- a/operators/pid_control_op.py
+++ b/operators/pid_control_op.py
@@ -1,3 +1,59 @@
+""" 
+# PID Control operator
+
+`pid` control operator computes the command that needs to be executed to follow the given waypoints. 
+It reacts to the car current speed and position in a way that accelerates or brake according to previous inputs.
+
+## Inputs
+
+- waypoints coordinates to follow.
+
+## Outputs
+
+- throttle, steering (rad) and braking.
+
+## Graph Description
+
+```yaml
+  - id: pid_control_op
+    operator:
+      python: ../../operators/pid_control_op.py
+      outputs:
+        - control
+      inputs:
+        position: oasis_agent/position
+        speed: oasis_agent/speed
+        waypoints: fot_op/waypoints
+```
+
+## Graph Viz
+
+```mermaid
+        flowchart TB
+  oasis_agent
+subgraph fot_op
+  fot_op/op[op]
+end
+subgraph pid_control_op
+  pid_control_op/op[op]
+end
+  oasis_agent -- position --> pid_control_op/op
+  oasis_agent -- speed --> pid_control_op/op
+  fot_op/op -- waypoints --> pid_control_op/op
+  pid_control_op/op -- control --> oasis_agent
+```
+
+## Hyperparameters consider changing
+
+See: https://en.wikipedia.org/wiki/PID_controller
+
+```
+pid_p = 0.1
+pid_d = 0.0
+pid_i = 0.05
+dt = 1.0 / 20   
+```
+"""
 import math
 import time
 from collections import deque
@@ -161,7 +217,7 @@ class Operator:
     ):
         """Handle input.
         Args:
-            dora_input["id"](str): Id of the input declared in the yaml configuration
+            dora_input["id"]  (str): Id of the input declared in the yaml configuration
             dora_input["value"] (arrow.array(UInt8)): Bytes message of the input
             send_output (Callable[[str, bytes]]): Function enabling sending output back to dora.
         """

--- a/operators/plot.py
+++ b/operators/plot.py
@@ -5,9 +5,14 @@ import cv2
 import numpy as np
 import pyarrow as pa
 from dora import DoraStatus
-from dora_utils import (LABELS, get_extrinsic_matrix, get_intrinsic_matrix,
-                        get_projection_matrix, local_points_to_camera_view,
-                        location_to_camera_view)
+from dora_utils import (
+    LABELS,
+    get_extrinsic_matrix,
+    get_intrinsic_matrix,
+    get_projection_matrix,
+    local_points_to_camera_view,
+    location_to_camera_view,
+)
 from scipy.spatial.transform import Rotation as R
 
 pa.array([])  # See: https://github.com/apache/arrow/issues/34994
@@ -84,7 +89,7 @@ class Operator:
         send_output: Callable[[str, bytes], None],
     ):
         if "waypoints" == dora_input["id"]:
-            waypoints = np.frombuffer(dora_input["data"], np.float32)
+            waypoints = np.array(dora_input["value"]).view(np.float32)
             waypoints = waypoints.reshape((-1, 3))
             waypoints = waypoints[:, :2]
             # Adding z axis for plot
@@ -94,7 +99,7 @@ class Operator:
             self.waypoints = waypoints
 
         elif "gps_waypoints" == dora_input["id"]:
-            gps_waypoints = np.frombuffer(dora_input["data"], np.float32)
+            gps_waypoints = np.array(dora_input["value"]).view(np.float32)
             gps_waypoints = gps_waypoints.reshape((-1, 3))
             gps_waypoints = gps_waypoints[:, :2]
             # Adding z axis for plot
@@ -104,7 +109,7 @@ class Operator:
             self.gps_waypoints = gps_waypoints
 
         elif "control" == dora_input["id"]:
-            self.control = np.frombuffer(dora_input["data"], np.float16)
+            self.control = np.array(dora_input["value"]).view(np.float16)
 
         elif "obstacles_bbox" == dora_input["id"]:
             self.obstacles_bbox = (
@@ -112,36 +117,40 @@ class Operator:
             )
 
         elif "traffic_sign_bbox" == dora_input["id"]:
-            self.traffic_sign_bbox = np.frombuffer(
-                dora_input["data"], np.int32
-            ).reshape((-1, 6))
+            self.traffic_sign_bbox = (
+                np.array(dora_input["value"]).view(np.int32).reshape((-1, 6))
+            )
 
         elif "obstacles_id" == dora_input["id"]:
-            self.obstacles_id = np.frombuffer(
-                dora_input["data"], np.int32
-            ).reshape((-1, 7))
+            self.obstacles_id = (
+                np.array(dora_input["value"]).view(np.int32).reshape((-1, 7))
+            )
 
         elif "obstacles" == dora_input["id"]:
-            obstacles = np.frombuffer(dora_input["data"], np.float32).reshape(
-                (-1, 5)
-            )[:, :3]
+            obstacles = (
+                np.array(dora_input["value"])
+                .view(np.float32)
+                .reshape((-1, 5))[:, :3]
+            )
             self.obstacles = obstacles
 
         elif "lanes" == dora_input["id"]:
-            lanes = np.frombuffer(dora_input["data"], np.int32).reshape(
-                (-1, 30, 2)
+            lanes = (
+                np.array(dora_input["value"])
+                .view(np.int32)
+                .reshape((-1, 30, 2))
             )
             self.lanes = lanes
 
         elif "global_lanes" == dora_input["id"]:
-            global_lanes = np.frombuffer(
-                dora_input["data"], np.float32
-            ).reshape((-1, 3))
+            global_lanes = (
+                np.array(dora_input["value"]).view(np.float32).reshape((-1, 3))
+            )
             self.global_lanes = global_lanes
 
         elif "drivable_area" == dora_input["id"]:
-            drivable_area = np.frombuffer(dora_input["data"], np.int32).reshape(
-                (1, -1, 2)
+            drivable_area = (
+                np.array(dora_input["value"]).view(np.int32).reshape((1, -1, 2))
             )
             self.drivable_area = drivable_area
 
@@ -149,7 +158,7 @@ class Operator:
             # Add sensor transform
 
             self.last_position = self.position
-            self.position = np.frombuffer(dora_input["data"], np.float32)
+            self.position = np.array(dora_input["value"]).view(np.float32)
             if len(self.last_position) == 0:
                 return DoraStatus.CONTINUE
 
@@ -158,7 +167,7 @@ class Operator:
             ) * 20
 
         elif "lidar_pc" == dora_input["id"]:
-            point_cloud = np.frombuffer(dora_input["data"], np.float32)
+            point_cloud = np.array(dora_input["value"]).view(np.float32)
             point_cloud = point_cloud.reshape((-1, 3))
             # To camera coordinate
             # The latest coordinate space is the unreal space.

--- a/operators/plot.py
+++ b/operators/plot.py
@@ -5,14 +5,9 @@ import cv2
 import numpy as np
 import pyarrow as pa
 from dora import DoraStatus
-from dora_utils import (
-    LABELS,
-    get_extrinsic_matrix,
-    get_intrinsic_matrix,
-    get_projection_matrix,
-    local_points_to_camera_view,
-    location_to_camera_view,
-)
+from dora_utils import (LABELS, get_extrinsic_matrix, get_intrinsic_matrix,
+                        get_projection_matrix, local_points_to_camera_view,
+                        location_to_camera_view)
 from scipy.spatial.transform import Rotation as R
 
 pa.array([])  # See: https://github.com/apache/arrow/issues/34994

--- a/operators/plot.py
+++ b/operators/plot.py
@@ -1,3 +1,8 @@
+""" 
+# Plot operator
+
+Plot operator takes outputs from the graph and plot it on the camera frame.
+"""
 import time
 from typing import Callable
 
@@ -51,7 +56,7 @@ lineType = 2
 
 class Operator:
     """
-    Compute a `control` based on the position and the waypoints of the car.
+    Plot inputs using cv2.imshow
     """
 
     def __init__(self):

--- a/operators/strong_sort_op.py
+++ b/operators/strong_sort_op.py
@@ -54,16 +54,16 @@ class Operator:
     ) -> DoraStatus:
 
         if dora_input["id"] == "image":
-            frame = np.frombuffer(
-                dora_input["data"],
+            frame = np.array(
+                dora_input["value"],
                 np.uint8,
             ).reshape((IMAGE_HEIGHT, IMAGE_WIDTH, 4))
 
             self.frame = frame[:, :, :3]
 
         elif dora_input["id"] == "obstacles_bbox" and len(self.frame) != 0:
-            obstacles = np.frombuffer(dora_input["data"], np.int32).reshape(
-                (-1, 6)
+            obstacles = (
+                np.array(dora_input["value"]).view(np.int32).reshape((-1, 6))
             )
             if obstacles.shape[0] == 0:
                 # self.model.increment_ages()

--- a/operators/strong_sort_op.py
+++ b/operators/strong_sort_op.py
@@ -2,9 +2,12 @@ from typing import Callable
 
 import cv2
 import numpy as np
+import pyarrow as pa
 import torch
 from dora import DoraStatus
 from strong_sort import StrongSORT
+
+pa.array([])  # See: https://github.com/apache/arrow/issues/34994
 
 IMAGE_WIDTH = 1920
 IMAGE_HEIGHT = 1080
@@ -66,7 +69,7 @@ class Operator:
                 # self.model.increment_ages()
                 send_output(
                     "obstacles_id",
-                    np.array([]).tobytes(),
+                    pa.array(np.array([]).view(np.uint8).ravel()),
                     dora_input["metadata"],
                 )
                 return DoraStatus.CONTINUE
@@ -86,7 +89,7 @@ class Operator:
 
                     send_output(
                         "obstacles_id",
-                        outputs.tobytes(),
+                        pa.array(outputs.ravel().view(np.uint8)),
                         dora_input["metadata"],
                     )
 

--- a/operators/webcam_op.py
+++ b/operators/webcam_op.py
@@ -5,6 +5,10 @@ from dora import DoraStatus
 
 OUTPUT_WIDTH = 1920
 OUTPUT_HEIGHT = 1080
+import numpy as np
+import pyarrow as pa
+
+pa.array([])
 
 
 class Operator:
@@ -35,7 +39,11 @@ class Operator:
         if ret:
             frame = cv2.resize(frame, (OUTPUT_WIDTH, OUTPUT_HEIGHT))
             frame = cv2.cvtColor(frame, cv2.COLOR_BGR2BGRA)
-            send_output("image", frame.tobytes(), dora_input["metadata"])
+            send_output(
+                "image",
+                pa.array(frame.view(np.uint8).flatten()),
+                dora_input["metadata"],
+            )
         else:
             print("could not get webcam.")
         return DoraStatus.CONTINUE

--- a/operators/webcam_op.py
+++ b/operators/webcam_op.py
@@ -41,7 +41,7 @@ class Operator:
             frame = cv2.cvtColor(frame, cv2.COLOR_BGR2BGRA)
             send_output(
                 "image",
-                pa.array(frame.view(np.uint8).flatten()),
+                pa.array(frame.ravel().view(np.uint8)),
                 dora_input["metadata"],
             )
         else:

--- a/operators/yolov5_op.py
+++ b/operators/yolov5_op.py
@@ -28,6 +28,13 @@ class Operator:
             )
         else:
             # Without internet
+            #
+            # To install:
+            # cd $DORA_HOME_DEP/dependecies # Optional
+            # git clone https://github.com/ultralytics/yolov5.git
+            # rm yolov5/.git -rf
+            # Add YOLOV5_PATH and YOLOV5_WEIGHT_PATH in your YAML graph
+
             self.model = torch.hub.load(
                 YOLOV5_PATH,
                 "custom",

--- a/operators/yolov5_op.py
+++ b/operators/yolov5_op.py
@@ -72,6 +72,6 @@ class Operator:
             ]  # xyxy -> xxyy
             arrays[:, 4] *= 100
             arrays = arrays.astype(np.int32)
-            arrays = pa.array(arrays.view(np.uint8).flatten())
+            arrays = pa.array(arrays.ravel().view(np.uint8))
             send_output("bbox", arrays, dora_input["metadata"])
             return DoraStatus.CONTINUE

--- a/operators/yolov5_op.py
+++ b/operators/yolov5_op.py
@@ -1,3 +1,56 @@
+""" 
+# Yolov5 operator
+
+`Yolov5` object detection operator generates bounding boxes on images where it detects object. 
+
+More info here: [https://github.com/ultralytics/yolov5](https://github.com/ultralytics/yolov5)
+
+`Yolov5` has not been finetuned on the simulation and is directly importing weight from Pytorch Hub.
+
+In case you want to run `yolov5` without internet you can clone [https://github.com/ultralytics/yolov5](https://github.com/ultralytics/yolov5) and download the weights you want to use from [the release page](https://github.com/ultralytics/yolov5/releases/tag/v7.0) and then specify within the yaml graph the two environments variables:
+- `YOLOV5_PATH: YOUR/PATH` 
+- `YOLOV5_WEIGHT_PATH: YOUR/WEIGHT/PATH`
+
+You can also choose to allocate the model in GPU using the environment variable:
+- `PYTORCH_DEVICE: cuda # or cpu`
+
+## Inputs
+
+- image as 1920x1080xBGR array.
+
+## Outputs
+
+- Bounding box coordinates as well as the confidence and class label as output.
+
+## Graph Description
+
+```yaml
+  - id: yolov5
+    operator: 
+      outputs:
+        - bbox
+      inputs:
+        image: webcam/image
+      python: ../../operators/yolov5_op.py
+```
+
+## Graph Visualisation
+
+```mermaid
+        flowchart TB
+  oasis_agent
+subgraph yolov5
+  yolov5/op[op]
+end
+subgraph obstacle_location_op
+  obstacle_location_op/op[op]
+end
+  oasis_agent -- image --> yolov5/op
+  yolov5/op -- bbox as obstacles_bbox --> obstacle_location_op/op
+```
+"""
+
+
 import os
 from typing import Callable
 
@@ -59,9 +112,10 @@ class Operator:
         dora_input: dict,
         send_output: Callable[[str, bytes], None],
     ) -> DoraStatus:
-        """Handle image
+        """
+        Handle image
         Args:
-            dora_input["id"](str): Id of the input declared in the yaml configuration
+            dora_input["id"] (str): Id of the input declared in the yaml configuration
             dora_input["value"] (arrow.array (UInt8)): Bytes message of the input
             send_output (Callable[[str, bytes]]): Function enabling sending output back to dora.
         """

--- a/operators/yolov5_op.py
+++ b/operators/yolov5_op.py
@@ -55,7 +55,7 @@ class Operator:
         """Handle image
         Args:
             dora_input["id"](str): Id of the input declared in the yaml configuration
-            dora_input["data"] (bytes): Bytes message of the input
+            dora_input["value"] (arrow.array (UInt8)): Bytes message of the input
             send_output (Callable[[str, bytes]]): Function enabling sending output back to dora.
         """
         if dora_input["id"] == "image":

--- a/scripts/run_simulator.sh
+++ b/scripts/run_simulator.sh
@@ -5,4 +5,4 @@ if [ -z "$CARLA_HOME" ]; then
     exit 1
 fi
 
-${CARLA_HOME}/CarlaUE4.sh ResX=800 -ResY=600 -carla-server -world-port=2000 -benchmark -fps=5 -nosound -quality-level=Low  -RenderOffScreen
+${CARLA_HOME}/CarlaUE4.sh ResX=800 -ResY=600 -carla-server -world-port=2000 -benchmark -fps=20 -nosound -quality-level=Low  -RenderOffScreen


### PR DESCRIPTION
This implementation makes use of the newly introduce `arrow.array` to share messages between nodes and operators with zero-copy.

The effective changes are:
- replace sending output from using `Pybytes` to `arrow array`:
```python
# From
outputs.tobytes(),
# To
pa.array(outputs.ravel().view(np.uint8))
```
> `ravel()` makes the array 1-Dimensional without copy. This also makes sure that the data is contiguous.
> `.view(np.uint8)` makes the array viewed as bytes.

- replace receiving input from `Pybytes` to `arrow.array`:
```python
# From
            self.position = np.frombuffer(dora_input["data"], np.float32)
# To
            self.position = np.array(dora_input["value"]).view(np.float32)
```
> `view()` makes changing the dtype without copy

There is few 